### PR TITLE
Require l3keys2e

### DIFF
--- a/chemformula.sty
+++ b/chemformula.sty
@@ -26,7 +26,7 @@
 %
 % The Current Maintainer of this work is Clemens Niederberger.
 % --------------------------------------------------------------------------
-\RequirePackage{tikz,amsmath,xfrac,nicefrac}
+\RequirePackage{l3keys2e,tikz,amsmath,xfrac,nicefrac}
 \usetikzlibrary{arrows.meta}
 
 \ExplSyntaxOn


### PR DESCRIPTION
No longer loaded by xfrac.